### PR TITLE
Add config generator for Chromium along with Google Chrome

### DIFF
--- a/tools/generate-config.sh
+++ b/tools/generate-config.sh
@@ -30,6 +30,28 @@ icon = "/usr/share/icons/hicolor/128x128/apps/google-chrome.png"
 END
 fi
 
+path=$(find_command_from_path chromium-browser)
+if [ -s "$path" ]; then
+  cat << END
+[[favorite_apps]]
+name = "Chromium"
+exec = "chromium-browser --enable-features=UseOzonePlatform --ozone-platform=wayland --disable-gpu"
+icon = "/usr/share/icons/hicolor/128x128/apps/chromium-browser.png"
+
+END
+fi
+
+path=$(find_command_from_path chromium)
+if [ -s "$path" ]; then
+  cat << END
+[[favorite_apps]]
+name = "Chromium"
+exec = "chromium --enable-features=UseOzonePlatform --ozone-platform=wayland --disable-gpu"
+icon = "/usr/share/icons/hicolor/128x128/apps/chromium.png"
+
+END
+fi
+
 path=$(find_command_from_path weston-terminal)
 if [ -s "$path" ]; then
   cat << END


### PR DESCRIPTION
## Context

Hello. I gave a try on ZEN/aarch64 using a Rock 5B single-board-computer and it mostly went fine (tho I experienced couple of  minor building issues). Most notable problem is: there is no official Google Chrome distributed for aarch64 so we cannot demo Web Browsers are working as usual in ZEN VR environment.

Environment:

 - Rock 5B
 - Armbian 22.11.2 Jammy with Linux 5.10.110-rockchip-rk3588 (based on Ubuntu 22.04)
 - panfork-mesa driver installed for OpenGL ES 3.x hardware support

## Summary

Support for Chromium is essential for aarch64 users because Google doesn't provide official Chrome binaries for aarch64 and Firefox doesn't currently work well on ZEN.

As far as I tested, `chromium-browser` works fine as a drop-in-replacement for Google Chrome (with same command-line parameters to disable GPU acceleration). So, detecting Chromium as well seems a reasonable option for me.

## How to check behavior

```
$ cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=22.04
DISTRIB_CODENAME=jammy
DISTRIB_DESCRIPTION="Ubuntu 22.04.1 LTS"
$ sudo apt install chromium-browser
$ cd zen-release-manager/
$ ./zen-release generate-config
Generated /home/muo/.config/zen-desktop/config.toml

[wallpaper]
filepath = "/usr/local/share/backgrounds/zen/Zen_Wallpaper_Main_3840x2160.png"

[board]
initial_count = 3

[space]
default_app = "zennist"

[[favorite_apps]]
name = "Chromium"
exec = "chromium-browser --enable-features=UseOzonePlatform --ozone-platform=wayland --disable-gpu"
icon = "/usr/share/icons/hicolor/128x128/apps/chromium-browser.png"

[[favorite_apps]]
name="Weston Terminal"
exec="weston-terminal"
icon="/usr/share/weston/terminal.png"

[[favorite_apps]]
name="Nautilus"
exec="nautilus"
icon="/usr/share/icons/hicolor/scalable/apps/org.gnome.Nautilus.svg"

[[favorite_apps]]
name="Zen Object Viewer"
exec="zen-object-viewer"
icon="/usr/local/share/zen-object-viewer/assets/icon/3d_viewer_icon.gltf"
disable_2d=true
```