### PR TITLE
set config_dir properly when XDG_CONFIG_HOME is set

### DIFF
--- a/zen-release
+++ b/zen-release
@@ -108,8 +108,8 @@ clean() {
 
 generate_config() {
   config_dir="$XDG_CONFIG_HOME"
-  [ -z "$config_dir" ] && config_dir="$HOME"
-  config_dir="$config_dir/.config/zen-desktop"
+  [ -z "$config_dir" ] && config_dir="$HOME/.config"
+  config_dir="$config_dir/zen-desktop"
   mkdir -p "$config_dir"
 
   file_name="config.toml"


### PR DESCRIPTION
## Context

With current implementation, when `XDG_CONFIG_HOME` is defined (regardless its value) `./zen-release generate-config` will generate config at `$XDG_CONFIG_HOME/.config/zen-desktop/config.toml`.

Actually, `$XDG_CONFIG_HOME` should contains `.config` as part of it according to Freedesktop's document:

> $XDG_CONFIG_HOME defines the base directory relative to which user-specific
> configuration files should be stored.
> If $XDG_CONFIG_HOME is either not set or empty, a default equal to
> $HOME/.config should be used.
>
> from: <https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html>

Therefore, previous code generates config file at e.g. 
`~/.config/.config/zen-desktop/config.toml` when XDG_CONFIG_HOME is defined, which isn't expected.

As [Implementation of zen/config/config-parser.c of zwin-project/zen repository](https://github.com/zwin-project/zen/blob/736f1423db869cc7f86dfdbb16dc809c30264be4/zen/config/config-parser.c#L29-L31) reads config file at `~/.config/zen-desktop/config.toml`, it couldn't read config file at all.
### Reproduce the problem

run 

```sh
$ export XDG_CONFIG_HOME="$HOME/.config"
$ ./zen-release build deps
```

It'll generate `$HOME/.config/.config/zen-desktop/config.toml` 
## Summary

Append `.config/` only if `$XDG_CONFIG_HOME` isn't defined.
<!--
Please describe what you did here. If you have made changes to the appearance,
it would be helpful to include images as well.
-->

## How to check the behavior

run 

```sh
$ export XDG_CONFIG_HOME="$HOME/.config"
$ ./zen-release build deps
```
Then now it should generate `$HOME/.config/zen-desktop/config.toml` as expected.